### PR TITLE
fix: create database directory at runtime instead of copying at build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -19,9 +19,8 @@ RUN npm run build
 # Remove devDependencies after build
 RUN npm prune --production
 
-# The backend needs the database file
-# The database is located at the root of the backend directory
-COPY database ./database
+# Create the database directory (DB is initialized at runtime)
+RUN mkdir -p ./database
 
 # The backend runs on port 3001
 EXPOSE 3001


### PR DESCRIPTION
The database is initialized at runtime, so copying it during the Docker build is unnecessary. Replace COPY with mkdir to create an empty directory that gets populated when the container starts.