### PR TITLE
feat: add Top 10 Attack Surface Exposures track

### DIFF
--- a/ATTACK_SURFACE_PRESENTATION_GUIDE.md
+++ b/ATTACK_SURFACE_PRESENTATION_GUIDE.md
@@ -1,0 +1,190 @@
+# Top 10 Attack Surface Exposures - Presentation Guide
+
+## Overview
+
+This guide covers the **Top 10 Attack Surface Exposures (2026)** track. Unlike the
+OWASP Web and LLM lists — which catalogue *application vulnerability classes* — this
+track is about *exposures*: services, panels, and protocols that should never have
+been reachable from the public internet in the first place.
+
+The data comes from an analysis of ~3,000 real-world attack surfaces, reported by
+The Hacker News in ["The Top 10 Attack Surface Exposures in 2026"](https://thehackernews.com/2026/06/the-top-10-attack-surface-exposures-in.html)
+(underlying figures: Intruder's 2026 Attack Surface Management Index).
+
+**One-line framing for the audience:** *"The OWASP lists tell you how attackers break
+in. This list is about the doors you left open."*
+
+## Pre-Presentation Checklist
+
+This track is **100% static frontend content** — there is no backend, no live target,
+and no exploitation. That makes it the lowest-risk track to demo.
+
+- [ ] Frontend running (`npm start` in `frontend/`, or `docker-compose up`)
+- [ ] Page loads at `http://localhost:3000/asm`
+- [ ] Projector/screen share ready; browser zoom set so cards are legible
+- [ ] (Optional) Pre-expand the first card or two if you prefer to scroll-and-talk
+
+## How This Track Works (read before presenting)
+
+Everything lives on a **single page** (`/asm`) — there are no per-exposure sub-pages.
+The page has three parts:
+
+1. **Stats strip** — the headline numbers, plus the source link.
+2. **The ten cards** (AS01 → AS10) — each is one "slide".
+3. **Presentation Flow footer** — a one-paragraph recap and a link back home.
+
+Each card shows, at a glance: the rank, the exposure name, a **% of surfaces** chip, a
+**port/service** chip, a one-line description, and three example bullets. Every card
+also has a collapsible **"Talk-through details"** disclosure. Expand it to reveal:
+
+- a longer **summary**,
+- **🔎 What an attacker sees** — simulated recon scan output + the attacker's next move,
+- **💥 Impact** bullets,
+- **🛡️ How to fix it** — concrete fixes with config/command snippets,
+- **🏆 Best practices**.
+
+**Recommended technique:** keep the details collapsed and expand each card live as you
+reach it — the recon-scan reveal ("here's literally what the scanner sees") is the hook
+for each exposure. Read the title + stat + port, ask the room "what's the risk?", then
+expand to confirm with the scan, impact, and fix.
+
+## Presentation Flow (~25-35 minutes, scales to fit)
+
+### Introduction (5 minutes)
+
+1. **Open** at the home page (`/`) and click the **Attack Surface Top 10 (2026)** card.
+2. **Lead with the stats strip** — these land hard with any audience:
+   - **60%** had at least one HTTP panel exposed
+   - **49%** exposed a risky port or service
+   - **42%** had a database reachable directly from the internet
+   - **30%** exposed files or information that shouldn't be
+3. **Set the frame:** these aren't subtle code bugs — they're things switched on and
+   left facing the internet. Attackers don't break in so much as walk in; automated
+   scanners sweep the whole internet for exactly these every day.
+
+### Core Walk-Through (~2-3 min per exposure)
+
+Walk AS01 → AS10. For each: state the **stat + port**, expand **Talk-through details**,
+show the **recon scan**, then land the **impact** and the **one-line fix**.
+
+#### AS01 - MySQL Database Exposed (26% · 3306/tcp)
+- **What the scan shows:** port 3306 open, MySQL bound to `0.0.0.0`, no TLS required.
+- **Why it matters:** no exploit needed — point a credential-stuffing tool at root and
+  try common passwords. One guess = full read/write to every schema; a top driver of
+  mass-ransomware campaigns.
+- **The fix in one line:** bind to localhost, firewall 3306 to the app subnet, strong
+  unique creds, TLS + least privilege.
+
+#### AS02 - Postgres Database Exposed (16% · 5432/tcp)
+- **What the scan shows:** `listen_addresses = '*'`, and `psql` connecting with **no
+  password at all** thanks to `pg_hba.conf` `trust` auth.
+- **Why it matters:** instant superuser; dump or drop the whole cluster; `COPY`/extensions
+  can read host files or run code in some setups.
+- **The fix in one line:** `listen_addresses = 'localhost'`, never `trust` for remote
+  hosts (use `scram-sha-256`), firewall the port, TLS + scoped roles.
+
+#### AS03 - API Documentation Exposed (15% · HTTP/HTTPS)
+- **What the scan shows:** a public `swagger.json` listing `/api/admin/users`,
+  `/api/internal/debug`, `/api/payments/refund`.
+- **Why it matters:** it hands the attacker a complete, documented map of every endpoint,
+  parameter, and auth scheme — including internal/admin routes. GraphQL introspection
+  leaks the full schema the same way.
+- **The fix in one line:** disable docs/introspection in prod, authenticate any exposed
+  docs, and enforce authz on every route at the gateway (no security by obscurity).
+
+#### AS04 - WordPress Admin Panel Exposed (15% · HTTP/HTTPS)
+- **What the scan shows:** `wpscan` finds `/wp-login.php`, XML-RPC enabled, users
+  `admin`/`editor`, and a plugin with a known CVE.
+- **Why it matters:** relentless credential guessing plus the enormous plugin/theme CVE
+  surface → admin takeover, webshell/RCE, defacement, and a pivot off the web host.
+- **The fix in one line:** restrict `/wp-admin` to VPN/known IPs, disable `xmlrpc.php`,
+  enforce MFA + rate limiting, and patch/prune plugins aggressively.
+
+#### AS05 - Remote Desktop (RDP) Exposed (11% · 3389/tcp)
+- **What the scan shows:** RDP open and leaking `FILESRV01.corp.local` / domain `CORP`,
+  with **NLA not enforced**.
+- **Why it matters:** one of the most common ransomware entry points — password-spray the
+  leaked hostname, or fire a pre-auth exploit like BlueKeep. A single guess = an
+  interactive desktop inside the network, then AD compromise.
+- **The fix in one line:** never expose RDP (VPN / RD Gateway only), enforce NLA + MFA,
+  account lockout, patch and restrict source IPs.
+
+#### AS06 - SNMP Service Exposed (9% · 161/udp)
+- **What the scan shows:** `snmpwalk -c public` returns device model, hostname
+  `core-sw-01`, interfaces, and internal IP tables.
+- **Why it matters:** the default `public` string leaks a full internal network map; a
+  writable `private` string lets attackers reconfigure devices; open SNMP is also a DDoS
+  amplifier.
+- **The fix in one line:** keep 161/udp off the internet, use SNMPv3 (auth+priv), remove
+  default community strings, restrict to monitoring hosts, read-only.
+
+#### AS07 - phpMyAdmin Panel Exposed (8% · HTTP/HTTPS)
+- **What the scan shows:** `/phpmyadmin/` returns 200, the README leaks version 4.9.7,
+  and the login form is ready for brute-force.
+- **Why it matters:** the same prize as an exposed database (AS01) but through a friendly
+  browser UI — full DB control, and SQL-to-file RCE in some configurations.
+- **The fix in one line:** don't expose it (VPN/allowlist), put proxy auth + MFA in front,
+  remove it if unused, patch and use strong DB credentials.
+
+#### AS08 - UPnP Service Exposed (8% · 1900/udp)
+- **What the scan shows:** an SSDP `M-SEARCH` reveals a `rootDesc.xml` with a
+  `WANIPConnection` control URL.
+- **Why it matters:** a protocol meant for trusted LANs, on the WAN side — attackers
+  rewrite NAT/port-forward rules to expose internal hosts, enumerate the network, and
+  abuse the device for SSDP reflection DDoS.
+- **The fix in one line:** disable UPnP on the WAN, drop inbound 1900/udp, segment IoT,
+  and patch device firmware.
+
+#### AS09 - NTP Service Exposed (7% · 123/udp)
+- **What the scan shows:** `ntpdc monlist` returns a list of recent clients (internal
+  IPs) — a tiny request producing a large reply.
+- **Why it matters:** a powerful reflection/amplification DDoS weapon that also leaks
+  internal client addresses; leads to IP blocklisting and bandwidth costs.
+- **The fix in one line:** disable `monlist` (modern ntpd/chrony), default-deny status
+  queries, firewall 123/udp to real time servers, deploy BCP38 anti-spoofing.
+
+#### AS10 - RPC Portmapper Exposed (7% · 111/tcp+udp)
+- **What the scan shows:** `rpcinfo -p` enumerates `portmapper`, `nfs` (2049), `mountd`,
+  and `status` — a map of internal RPC services.
+- **Why it matters:** a roadmap to world-readable NFS exports and other legacy services,
+  and itself a DDoS amplification vector.
+- **The fix in one line:** block port 111, disable `rpcbind` where unused, lock down NFS
+  exports (`root_squash`, specific hosts), modernise to NFSv4 + Kerberos.
+
+### Optional grouping (if you're short on time)
+
+Rather than ten separate beats, cluster them:
+
+- **Exposed databases** — AS01 (MySQL), AS02 (Postgres), AS07 (phpMyAdmin gateway)
+- **Management panels / HTTP surfaces** — AS03 (API docs), AS04 (WordPress)
+- **Remote access** — AS05 (RDP)
+- **Legacy UDP services that also amplify DDoS** — AS06 (SNMP), AS08 (UPnP), AS09 (NTP),
+  AS10 (RPC)
+
+### Conclusion (5 minutes)
+
+1. **The key takeaway:** patching matters, but **attack-surface reduction** — turning off
+   and firewalling what never needed to be public — prevents whole classes of attack
+   *before a single exploit is written.*
+2. **Three recurring patterns:**
+   - Defaults left on (community strings, `trust` auth, blank/weak passwords).
+   - Management interfaces facing the whole internet instead of a VPN/allowlist.
+   - Legacy protocols (SNMP/UPnP/NTP/RPC) that double as DDoS amplifiers.
+3. **Next steps for the audience:**
+   - Continuously scan *your own* IP ranges for these exposures.
+   - Default-deny at the perimeter; put admin behind VPN/ZTNA.
+   - Treat attack-surface management as an ongoing process, not a one-time audit.
+
+## Presentation Tips
+
+- The recon-scan blocks are the emotional hook — "this is what an attacker sees about
+  *you*, today, with no effort." Pause on them.
+- Tie each exposure to a real headline (ransomware via RDP/MySQL, NTP/SSDP DDoS events).
+- You don't need network isolation for this track — there are no live targets — but keep
+  the standard "educational purposes only" framing consistent with the other tracks.
+
+## Resources
+
+- [The Top 10 Attack Surface Exposures in 2026 — The Hacker News](https://thehackernews.com/2026/06/the-top-10-attack-surface-exposures-in.html)
+- [OWASP Attack Surface Analysis Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Attack_Surface_Analysis_Cheat_Sheet.html)
+- [Shodan](https://www.shodan.io/) / [Censys](https://censys.io/) — see your own external footprint

--- a/OWASP_PRESENTATION_GUIDE.md
+++ b/OWASP_PRESENTATION_GUIDE.md
@@ -150,6 +150,43 @@
    - Training platforms
    - Security tools
 
+## Bonus Track: Top 10 Attack Surface Exposures (2026)
+
+This track shifts the lens from *application vulnerability classes* to *exposures* —
+services and panels that should never have been reachable from the public internet.
+It is based on an analysis of ~3,000 real-world attack surfaces (reported by The
+Hacker News, "The Top 10 Attack Surface Exposures in 2026").
+
+**Framing for the audience:** "The OWASP lists tell you how attackers break in. This
+list is about the doors you left open." Lead with the headline stats:
+- 60% had at least one HTTP panel exposed
+- 49% exposed a risky port or service
+- 42% had a database reachable directly from the internet
+- 30% exposed files or information that shouldn't be
+
+**Demo flow (navigate to `/asm`):** everything lives on a single page. Each of the ten
+cards has a collapsible **"Talk-through details"** section — expand it to reveal the
+simulated recon scan (what an attacker sees), the impact, and the remediation. Read the
+title + stat + port, then expand to confirm. For a full per-exposure script, see
+[`ATTACK_SURFACE_PRESENTATION_GUIDE.md`](./ATTACK_SURFACE_PRESENTATION_GUIDE.md).
+
+| #    | Exposure                  | Seen on | Talking point                                  |
+|------|---------------------------|---------|------------------------------------------------|
+| AS01 | MySQL Database Exposed    | 26%     | Open 3306 + weak root password = ransomware    |
+| AS02 | Postgres Database Exposed | 16%     | `trust` auth needs no password at all          |
+| AS03 | API Documentation Exposed | 15%     | Swagger/GraphQL maps every admin endpoint      |
+| AS04 | WordPress Admin Panel     | 15%     | /wp-login brute force + plugin CVEs            |
+| AS05 | Remote Desktop (RDP)      | 11%     | Top ransomware entry point; BlueKeep           |
+| AS06 | SNMP Service              | 9%      | Default `public` string leaks the network      |
+| AS07 | phpMyAdmin Panel          | 8%      | A browser gateway straight into the DB         |
+| AS08 | UPnP Service              | 8%      | WAN UPnP rewrites NAT; SSDP amplification      |
+| AS09 | NTP Service               | 7%      | monlist amplification DDoS                      |
+| AS10 | RPC Portmapper            | 7%      | rpcinfo enumerates NFS/NIS to target           |
+
+**Key takeaway:** patching matters, but attack-surface *reduction* — turning off and
+firewalling what never needed to be public — prevents whole classes of attack before
+a single exploit is written.
+
 ## Presentation Tips
 
 ### Audience Engagement

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -18,6 +18,10 @@
   background: linear-gradient(135deg, #0f0c29 0%, #302b63 50%, #24243e 100%);
 }
 
+.App-header-asm {
+  background: linear-gradient(135deg, #1c1917 0%, #7c2d12 50%, #431407 100%);
+}
+
 .App-header h1 {
   margin: 0;
   font-size: 2rem;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useLayoutEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, useLocation } from 'react-router-dom';
 import './App.css';
 
@@ -31,19 +31,37 @@ import LLM08VectorEmbeddingWeaknesses from './components/llm/LLM08VectorEmbeddin
 import LLM09Misinformation from './components/llm/LLM09Misinformation';
 import LLM10UnboundedConsumption from './components/llm/LLM10UnboundedConsumption';
 
+// Import Attack Surface Exposures Top 10 components
+import ASMHomePage from './components/asm/ASMHomePage';
+import ASMNavigation from './components/asm/ASMNavigation';
+
 function AppContent() {
   const location = useLocation();
   const isLLMRoute = location.pathname.startsWith('/llm');
   const isWebRoute = location.pathname.startsWith('/web');
+  const isASMRoute = location.pathname.startsWith('/asm');
+
+  // Scroll to the top whenever the route changes so each slide starts at the top.
+  // useLayoutEffect runs before the browser paints, so the new page never flashes
+  // at the previous scroll position.
+  useLayoutEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
 
   return (
     <div className="App">
-      <header className={`App-header ${isLLMRoute ? 'App-header-llm' : ''}`}>
+      <header
+        className={`App-header ${isLLMRoute ? 'App-header-llm' : ''} ${
+          isASMRoute ? 'App-header-asm' : ''
+        }`}
+      >
         <h1>
           {isLLMRoute
             ? '🤖 OWASP LLM Top 10 Demo 🤖'
             : isWebRoute
             ? '⚠️ OWASP Web Top 10 Demo ⚠️'
+            : isASMRoute
+            ? '🛰️ Top 10 Attack Surface Exposures 🛰️'
             : '⚠️ OWASP Top 10 Security Demo ⚠️'}
         </h1>
         <p className="warning">FOR EDUCATIONAL PURPOSES ONLY</p>
@@ -51,6 +69,7 @@ function AppContent() {
 
       {isWebRoute && <Navigation />}
       {isLLMRoute && <LLMNavigation />}
+      {isASMRoute && <ASMNavigation />}
 
       <main className="App-main">
         <Routes>
@@ -81,6 +100,9 @@ function AppContent() {
           <Route path="/llm/l08" element={<LLM08VectorEmbeddingWeaknesses />} />
           <Route path="/llm/l09" element={<LLM09Misinformation />} />
           <Route path="/llm/l10" element={<LLM10UnboundedConsumption />} />
+
+          {/* Attack Surface Exposures Top 10 — single summary page */}
+          <Route path="/asm" element={<ASMHomePage />} />
         </Routes>
       </main>
     </div>

--- a/frontend/src/components/LandingPage.css
+++ b/frontend/src/components/LandingPage.css
@@ -62,6 +62,33 @@
   box-shadow: 0 4px 16px rgba(48, 43, 99, 0.3);
 }
 
+.landing-card--asm {
+  background: linear-gradient(135deg, #7c2d12, #c2410c, #ea580c);
+  color: white;
+  box-shadow: 0 4px 16px rgba(234, 88, 12, 0.3);
+}
+
+.landing-card--asm::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: radial-gradient(circle at 30% 50%, rgba(249, 115, 22, 0.2) 0%, transparent 60%),
+              radial-gradient(circle at 70% 50%, rgba(251, 146, 60, 0.18) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.landing-card--asm .landing-card__year {
+  background: rgba(255, 255, 255, 0.2);
+}
+
+.landing-card--asm .landing-card__cta {
+  background: rgba(255, 255, 255, 0.2);
+  color: white;
+}
+
 .landing-card--llm::before {
   content: '';
   position: absolute;

--- a/frontend/src/components/LandingPage.tsx
+++ b/frontend/src/components/LandingPage.tsx
@@ -34,6 +34,17 @@ const LandingPage: React.FC = () => {
           </p>
           <span className="landing-card__cta">Explore LLM Top 10 &rarr;</span>
         </Link>
+
+        <Link to="/asm" className="landing-card landing-card--asm">
+          <span className="landing-card__year">2026</span>
+          <h2>Attack Surface Top 10</h2>
+          <p>
+            The exposures attackers find most often across the internet — exposed
+            databases, admin panels, and legacy services that should never face
+            the public.
+          </p>
+          <span className="landing-card__cta">Explore Attack Surface Top 10 &rarr;</span>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/asm/ASMHomePage.css
+++ b/frontend/src/components/asm/ASMHomePage.css
@@ -1,0 +1,403 @@
+.asm-home-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+.asm-hero-section {
+  text-align: center;
+  padding: 3rem 2rem;
+  background: linear-gradient(135deg, #1c1917, #431407, #7c2d12);
+  border-radius: 16px;
+  margin-bottom: 2rem;
+  color: white;
+  position: relative;
+  overflow: hidden;
+}
+
+.asm-hero-section::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: radial-gradient(circle at 30% 50%, rgba(249, 115, 22, 0.18) 0%, transparent 60%),
+              radial-gradient(circle at 70% 50%, rgba(251, 146, 60, 0.15) 0%, transparent 60%);
+  pointer-events: none;
+}
+
+.asm-hero-section h1 {
+  font-size: 2.5rem;
+  margin: 0 0 1rem 0;
+  position: relative;
+}
+
+.asm-hero-description {
+  font-size: 1.2rem;
+  color: rgba(255, 255, 255, 0.85);
+  max-width: 720px;
+  margin: 0 auto 1rem auto;
+  line-height: 1.6;
+  position: relative;
+}
+
+.asm-hero-subtitle {
+  display: inline-block;
+  background: linear-gradient(135deg, #f97316, #ea580c);
+  padding: 0.5rem 1.5rem;
+  border-radius: 25px;
+  font-weight: bold;
+  font-size: 0.95rem;
+  position: relative;
+}
+
+.asm-stats-strip {
+  background: white;
+  border: 1px solid #e0e0e0;
+  border-radius: 12px;
+  padding: 1.5rem;
+  margin-bottom: 3rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+}
+
+.asm-stats-caption {
+  text-align: center;
+  margin: 0 0 1rem 0;
+  font-weight: bold;
+  color: #7c2d12;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.85rem;
+}
+
+.asm-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.asm-source {
+  text-align: center;
+  margin: 1rem 0 0 0;
+  font-size: 0.8rem;
+  color: #78716c;
+}
+
+.asm-source a {
+  color: #ea580c;
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.asm-source a:hover {
+  color: #c2410c;
+  text-decoration: underline;
+}
+
+.asm-stat {
+  text-align: center;
+  padding: 1rem;
+  border-radius: 10px;
+  background: linear-gradient(135deg, #fff7ed, #ffedd5);
+}
+
+.asm-stat__value {
+  display: block;
+  font-size: 2rem;
+  font-weight: bold;
+  color: #ea580c;
+}
+
+.asm-stat__label {
+  display: block;
+  font-size: 0.85rem;
+  color: #7c2d12;
+  margin-top: 0.25rem;
+  line-height: 1.3;
+}
+
+.asm-vuln-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+  /* Don't stretch siblings when one card's details are expanded. */
+  align-items: start;
+}
+
+.asm-vuln-card {
+  background: white;
+  border-radius: 12px;
+  padding: 1.5rem;
+  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e0e0e0;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.asm-vuln-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+}
+
+.asm-vuln-card .vuln-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.asm-vuln-card .vuln-number {
+  background: linear-gradient(135deg, #f97316, #ea580c);
+  color: white;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 0.85rem;
+  flex-shrink: 0;
+}
+
+.asm-vuln-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #1c1917;
+}
+
+.asm-vuln-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.75rem;
+}
+
+.asm-chip {
+  font-size: 0.72rem;
+  font-weight: bold;
+  padding: 0.2rem 0.6rem;
+  border-radius: 20px;
+  white-space: nowrap;
+}
+
+.asm-chip--stat {
+  background: #ffedd5;
+  color: #c2410c;
+}
+
+.asm-chip--port {
+  background: #f1f5f9;
+  color: #475569;
+  font-family: 'Courier New', monospace;
+}
+
+.asm-vuln-card .vuln-description {
+  color: #555;
+  font-size: 0.9rem;
+  margin: 0 0 0.75rem 0;
+  line-height: 1.4;
+}
+
+.asm-vuln-card .vuln-examples {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 1rem 0;
+}
+
+.asm-vuln-card .vuln-examples li {
+  color: #666;
+  font-size: 0.85rem;
+  padding: 0.2rem 0;
+}
+
+.asm-vuln-card .vuln-examples li::before {
+  content: '>';
+  color: #f97316;
+  font-weight: bold;
+  margin-right: 0.5rem;
+}
+
+.asm-card-details {
+  margin-top: 0.75rem;
+  border-top: 1px solid #f1f5f9;
+  padding-top: 0.75rem;
+}
+
+.asm-card-details > summary {
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 0.85rem;
+  color: #ea580c;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  user-select: none;
+}
+
+.asm-card-details > summary::-webkit-details-marker {
+  display: none;
+}
+
+.asm-card-details > summary::before {
+  content: '▸';
+  display: inline-block;
+  transition: transform 0.2s ease;
+}
+
+.asm-card-details[open] > summary::before {
+  transform: rotate(90deg);
+}
+
+.asm-card-details > summary:hover {
+  color: #c2410c;
+}
+
+.asm-card-summary {
+  margin: 0.85rem 0 0 0;
+  font-size: 0.85rem;
+  color: #555;
+  line-height: 1.45;
+}
+
+.asm-detail-block {
+  margin-top: 0.85rem;
+}
+
+.asm-detail-block h4 {
+  margin: 0 0 0.4rem 0;
+  font-size: 0.85rem;
+  color: #1c1917;
+}
+
+.asm-detail-block ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.asm-scan {
+  background: #0f172a;
+  color: #e2e8f0;
+  font-family: 'Courier New', monospace;
+  font-size: 0.72rem;
+  line-height: 1.4;
+  padding: 0.75rem;
+  border-radius: 8px;
+  overflow-x: auto;
+  margin: 0 0 0.5rem 0;
+  white-space: pre;
+}
+
+.asm-attacker-next {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #721c24;
+  line-height: 1.45;
+}
+
+.asm-impact li,
+.asm-best-practices li {
+  font-size: 0.82rem;
+  color: #555;
+  line-height: 1.4;
+  padding: 0.2rem 0 0.2rem 1rem;
+  position: relative;
+}
+
+.asm-impact li::before,
+.asm-best-practices li::before {
+  content: '•';
+  color: #f97316;
+  position: absolute;
+  left: 0;
+}
+
+.asm-fixes li {
+  font-size: 0.82rem;
+  color: #555;
+  line-height: 1.4;
+  padding: 0.35rem 0;
+}
+
+.asm-fixes code {
+  display: block;
+  margin-top: 0.3rem;
+  background: #f1f5f9;
+  color: #c2410c;
+  font-family: 'Courier New', monospace;
+  font-size: 0.72rem;
+  padding: 0.35rem 0.5rem;
+  border-radius: 6px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.asm-presentation-info {
+  text-align: center;
+  margin-top: 3rem;
+  padding: 2rem;
+  background: linear-gradient(135deg, #fff7ed, #ffedd5);
+  border-radius: 12px;
+}
+
+.asm-presentation-info h2 {
+  color: #1c1917;
+  margin: 0 0 1rem 0;
+}
+
+.asm-presentation-info p {
+  color: #555;
+  max-width: 600px;
+  margin: 0 auto 1.5rem auto;
+  line-height: 1.6;
+}
+
+.asm-start-button {
+  display: inline-block;
+  background: linear-gradient(135deg, #f97316, #ea580c);
+  color: white !important;
+  text-decoration: none;
+  padding: 1rem 2rem;
+  border-radius: 25px;
+  font-weight: bold;
+  font-size: 1.1rem;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.asm-start-button:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 16px rgba(234, 88, 12, 0.3);
+  color: white;
+}
+
+.asm-back-link {
+  display: inline-block;
+  margin-top: 1rem;
+  color: #ea580c;
+  font-size: 0.9rem;
+}
+
+.asm-back-link:hover {
+  color: #c2410c;
+}
+
+@media (max-width: 768px) {
+  .asm-home-page {
+    padding: 1rem;
+  }
+
+  .asm-hero-section {
+    padding: 2rem 1rem;
+  }
+
+  .asm-hero-section h1 {
+    font-size: 1.8rem;
+  }
+
+  .asm-vuln-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/frontend/src/components/asm/ASMHomePage.tsx
+++ b/frontend/src/components/asm/ASMHomePage.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { exposures, surfaceStats } from "./asmExposures";
+import "./ASMHomePage.css";
+
+const ASMHomePage: React.FC = () => {
+  return (
+    <div className="asm-home-page">
+      <div className="asm-hero-section">
+        <h1>Top 10 Attack Surface Exposures</h1>
+        <p className="asm-hero-description">
+          Beyond application bugs, the fastest way in is often a service that
+          should never have been reachable at all — an exposed database, admin
+          panel, or legacy protocol. These are the ten exposures found most often
+          across the internet.
+        </p>
+        <span className="asm-hero-subtitle">Attack Surface Analysis (2026)</span>
+      </div>
+
+      <div className="asm-stats-strip">
+        <p className="asm-stats-caption">{surfaceStats.analysed}</p>
+        <div className="asm-stats-grid">
+          {surfaceStats.highlights.map((s) => (
+            <div key={s.value} className="asm-stat">
+              <span className="asm-stat__value">{s.value}</span>
+              <span className="asm-stat__label">{s.label}</span>
+            </div>
+          ))}
+        </div>
+        <p className="asm-source">
+          Source:{" "}
+          <a
+            href={surfaceStats.source.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {surfaceStats.source.label}
+          </a>
+        </p>
+      </div>
+
+      <div>
+        <h2>The Top 10 Exposures (2026)</h2>
+        <div className="asm-vuln-grid">
+          {exposures.map((exposure) => (
+            <div key={exposure.id} className="asm-vuln-card">
+              <div className="vuln-header">
+                <span className="vuln-number">{exposure.rank}</span>
+                <h3>
+                  {exposure.shortId} - {exposure.title}
+                </h3>
+              </div>
+              <div className="asm-vuln-meta">
+                <span className="asm-chip asm-chip--stat">{exposure.stat} of surfaces</span>
+                <span className="asm-chip asm-chip--port">{exposure.port}</span>
+              </div>
+              <p className="vuln-description">{exposure.cardDescription}</p>
+              <ul className="vuln-examples">
+                {exposure.examples.map((example, i) => (
+                  <li key={i}>{example}</li>
+                ))}
+              </ul>
+
+              <details className="asm-card-details">
+                <summary>Talk-through details</summary>
+
+                <p className="asm-card-summary">{exposure.summary}</p>
+
+                <div className="asm-detail-block">
+                  <h4>🔎 What an attacker sees</h4>
+                  <pre className="asm-scan">{exposure.scan.join("\n")}</pre>
+                  <p className="asm-attacker-next">{exposure.attackerNext}</p>
+                </div>
+
+                <div className="asm-detail-block">
+                  <h4>💥 Impact</h4>
+                  <ul className="asm-impact">
+                    {exposure.impact.map((item, i) => (
+                      <li key={i}>{item}</li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div className="asm-detail-block">
+                  <h4>🛡️ How to fix it</h4>
+                  <ul className="asm-fixes">
+                    {exposure.fixes.map((fix) => (
+                      <li key={fix.title}>
+                        <strong>{fix.title}</strong> — {fix.detail}
+                        <code>{fix.code}</code>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+
+                <div className="asm-detail-block">
+                  <h4>🏆 Best practices</h4>
+                  <ul className="asm-best-practices">
+                    {exposure.bestPractices.map((bp) => (
+                      <li key={bp.term}>
+                        <strong>{bp.term}:</strong> {bp.text}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </details>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="asm-presentation-info">
+        <h2>Presentation Flow</h2>
+        <p>
+          Walk the room through the exposures from AS01 to AS10. Each card shows
+          the service, the port it listens on, the share of attack surfaces it
+          affects, and what an attacker does with it — enough to talk through the
+          real-world impact and how to close the door.
+        </p>
+        <div>
+          <Link to="/" className="asm-back-link">
+            &larr; Back to OWASP Top 10
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ASMHomePage;

--- a/frontend/src/components/asm/ASMNavigation.css
+++ b/frontend/src/components/asm/ASMNavigation.css
@@ -1,0 +1,80 @@
+.asm-navigation {
+  background: linear-gradient(135deg, #1c1917, #7c2d12);
+  padding: 0.75rem 1rem;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+}
+
+.asm-nav-container {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.asm-nav-item {
+  padding: 0.4rem 0.75rem;
+  border-radius: 20px;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.8rem;
+  font-weight: 500;
+  transition: all 0.2s ease;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.asm-nav-item:hover {
+  color: white;
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.asm-nav-item.active {
+  background: linear-gradient(135deg, #f97316, #ea580c);
+  color: white;
+  font-weight: bold;
+}
+
+.asm-home-link {
+  font-weight: bold;
+  border-right: 1px solid rgba(255, 255, 255, 0.2);
+  padding-right: 1rem;
+  margin-right: 0.25rem;
+}
+
+.asm-vulnerability-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.asm-nav-item .vuln-number {
+  background: rgba(255, 255, 255, 0.15);
+  color: #fb923c;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.7rem;
+  font-weight: bold;
+}
+
+.asm-nav-item.active .vuln-number {
+  background: rgba(255, 255, 255, 0.3);
+  color: white;
+}
+
+.asm-nav-item .vuln-title {
+  display: none;
+}
+
+@media (min-width: 1024px) {
+  .asm-nav-item .vuln-title {
+    display: inline;
+  }
+}

--- a/frontend/src/components/asm/ASMNavigation.tsx
+++ b/frontend/src/components/asm/ASMNavigation.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+import "./ASMNavigation.css";
+
+const ASMNavigation: React.FC = () => {
+  const location = useLocation();
+
+  return (
+    <nav className="asm-navigation">
+      <div className="asm-nav-container">
+        <Link to="/" className="asm-nav-item asm-home-link">
+          🏠 Home
+        </Link>
+        <Link
+          to="/asm"
+          className={`asm-nav-item asm-home-link ${location.pathname === "/asm" ? "active" : ""}`}
+        >
+          Attack Surface Top 10
+        </Link>
+      </div>
+    </nav>
+  );
+};
+
+export default ASMNavigation;

--- a/frontend/src/components/asm/asmExposures.ts
+++ b/frontend/src/components/asm/asmExposures.ts
@@ -1,0 +1,673 @@
+// Data for the "Top 10 Attack Surface Exposures (2026)" track.
+//
+// Source: analysis of ~3,000 real-world attack surfaces, summarised by
+// The Hacker News, "The Top 10 Attack Surface Exposures in 2026".
+// Unlike the OWASP Web/LLM Top 10 (application-level vulnerability classes),
+// these are *exposures* — services and panels that should never have been
+// reachable from the public internet in the first place.
+
+export interface ExposureFix {
+  title: string;
+  detail: string;
+  code: string;
+}
+
+export interface ExposureBestPractice {
+  term: string;
+  text: string;
+}
+
+export interface Exposure {
+  id: string; // route segment, e.g. "as01"
+  rank: number; // 1-10
+  shortId: string; // "AS01"
+  title: string;
+  navTitle: string; // compact label for the nav bar
+  port: string; // typical port/service
+  stat: string; // share of analysed attack surfaces affected
+  cardDescription: string; // one-line summary for the home grid
+  summary: string; // longer paragraph for the detail page
+  examples: string[]; // bullet list for the home grid + nav context
+  scan: string[]; // simulated "what an attacker sees" recon output
+  attackerNext: string; // what the attacker does with that recon
+  impact: string[]; // business / security impact bullets
+  fixes: ExposureFix[]; // remediation grid
+  bestPractices: ExposureBestPractice[];
+}
+
+// Overall stats the article opened with — shown on the home page.
+export const surfaceStats = {
+  analysed: "3,000 attack surfaces analysed",
+  source: {
+    label: "The Hacker News — “The Top 10 Attack Surface Exposures in 2026”",
+    url: "https://thehackernews.com/2026/06/the-top-10-attack-surface-exposures-in.html",
+  },
+  highlights: [
+    { value: "60%", label: "had at least one HTTP panel exposed" },
+    { value: "49%", label: "exposed a risky port or service" },
+    { value: "42%", label: "had a database reachable from the internet" },
+    { value: "30%", label: "exposed files or information that shouldn't be" },
+  ],
+};
+
+export const exposures: Exposure[] = [
+  {
+    id: "as01",
+    rank: 1,
+    shortId: "AS01",
+    title: "MySQL Database Exposed",
+    navTitle: "AS01 - MySQL Exposed",
+    port: "3306/tcp",
+    stat: "26%",
+    cardDescription:
+      "Internet-facing MySQL on port 3306 — a routine target for credential brute-force and ransomware crews.",
+    summary:
+      "A MySQL server bound to all interfaces and reachable from the internet lets anyone attempt to connect. Attackers run automated credential brute-force and known-CVE checks; a weak, default, or blank root password gives full read/write access to every database. This is one of the most exploited exposures on the internet and has fuelled mass ransomware campaigns against hundreds of thousands of databases.",
+    examples: [
+      "Root brute-force on weak passwords",
+      "Bulk exfiltration of customer data",
+      "Databases dumped and held for ransom",
+    ],
+    scan: [
+      "$ nmap -sV -p 3306 203.0.113.10",
+      "PORT     STATE SERVICE VERSION",
+      "3306/tcp open  mysql   MySQL 5.7.38",
+      "| mysql-info:",
+      "|   Protocol: 10",
+      "|   Server bound to 0.0.0.0 (all interfaces)",
+      "|_  Auth: native password, no TLS required",
+    ],
+    attackerNext:
+      "From here an attacker simply points a credential-stuffing tool at the login and tries common root passwords — no exploit required, just an open door.",
+    impact: [
+      "Full read/write access to every schema once a single credential is guessed",
+      "Bulk exfiltration of customer records and PII",
+      "Databases wiped and replaced with a ransom note",
+      "A foothold for pivoting deeper into the internal network",
+    ],
+    fixes: [
+      {
+        title: "1. Bind to localhost",
+        detail: "Never expose the database engine to the public internet.",
+        code: "bind-address = 127.0.0.1",
+      },
+      {
+        title: "2. Firewall / private subnet",
+        detail: "Allow 3306 only from your application servers.",
+        code: "SG: allow 3306 from app-subnet only",
+      },
+      {
+        title: "3. Strong, unique credentials",
+        detail: "Eliminate default, blank, and reused passwords.",
+        code: "ALTER USER 'root'@'%' ...; use a secrets manager",
+      },
+      {
+        title: "4. TLS + least privilege",
+        detail: "Encrypt connections and scope app users tightly.",
+        code: "REQUIRE SSL; GRANT only needed privileges",
+      },
+    ],
+    bestPractices: [
+      { term: "Network segmentation", text: "Databases live in a private subnet, never a public one." },
+      { term: "Attack-surface monitoring", text: "Continuously scan your own ranges for an open 3306." },
+      { term: "Least privilege", text: "App accounts get only the schemas and operations they need." },
+      { term: "Patch management", text: "Keep the engine current to close known CVEs." },
+    ],
+  },
+  {
+    id: "as02",
+    rank: 2,
+    shortId: "AS02",
+    title: "Postgres Database Exposed",
+    navTitle: "AS02 - Postgres Exposed",
+    port: "5432/tcp",
+    stat: "16%",
+    cardDescription:
+      "PostgreSQL listening on 5432 across all interfaces — the same direct-access risk as exposed MySQL.",
+    summary:
+      "PostgreSQL listening on 5432 across all interfaces presents the same risk as an exposed MySQL instance: direct login attempts and weak-password brute force. Worse, a misconfigured pg_hba.conf with `trust` authentication accepts connections with no password at all, handing an attacker the superuser account instantly.",
+    examples: [
+      "`trust` auth requiring no password",
+      "Brute-force of the postgres superuser",
+      "Direct dump of every database",
+    ],
+    scan: [
+      "$ nmap -sV -p 5432 203.0.113.11",
+      "PORT     STATE SERVICE    VERSION",
+      "5432/tcp open  postgresql PostgreSQL DB 14.2",
+      "|_pgsql: listen_addresses = '*'",
+      "$ psql -h 203.0.113.11 -U postgres",
+      "psql: connected (no password — pg_hba 'trust')",
+    ],
+    attackerNext:
+      "With `trust` auth the attacker is already a superuser; otherwise they brute-force the postgres role and dump every database.",
+    impact: [
+      "Superuser access with a single weak or absent password",
+      "Exfiltration of every database on the cluster",
+      "Destructive DROP/ransom of business data",
+      "Use of COPY/extensions to read host files or run code in some setups",
+    ],
+    fixes: [
+      {
+        title: "1. Bind to localhost",
+        detail: "Only listen on interfaces that actually need it.",
+        code: "listen_addresses = 'localhost'",
+      },
+      {
+        title: "2. Fix pg_hba.conf",
+        detail: "Never use `trust` for remote connections.",
+        code: "host all all <app-cidr> scram-sha-256",
+      },
+      {
+        title: "3. Firewall the port",
+        detail: "Restrict 5432 to your application tier.",
+        code: "SG: allow 5432 from app-subnet only",
+      },
+      {
+        title: "4. TLS + scoped roles",
+        detail: "Encrypt traffic and give each app its own role.",
+        code: "ssl = on; GRANT least privilege per role",
+      },
+    ],
+    bestPractices: [
+      { term: "Network segmentation", text: "Keep the cluster off any public-facing interface." },
+      { term: "Authentication hardening", text: "Use scram-sha-256, never `trust`, for remote hosts." },
+      { term: "Least privilege", text: "Per-application roles scoped to their own databases." },
+      { term: "Patch management", text: "Track Postgres CVEs and upgrade minor releases promptly." },
+    ],
+  },
+  {
+    id: "as03",
+    rank: 3,
+    shortId: "AS03",
+    title: "API Documentation Exposed",
+    navTitle: "AS03 - API Docs Exposed",
+    port: "HTTP/HTTPS",
+    stat: "15%",
+    cardDescription:
+      "Public Swagger/OpenAPI or GraphQL introspection that maps every endpoint — including internal admin routes.",
+    summary:
+      "Swagger/OpenAPI UI, Redoc, or GraphQL introspection left publicly reachable hands an attacker a complete map of your API — every parameter, auth scheme, and often internal or admin-only route. It turns flaws that were merely obscure into a documented to-do list, dramatically lowering the effort to find and exploit them.",
+    examples: [
+      "Public /swagger or /api-docs",
+      "GraphQL introspection enabled in prod",
+      "Internal/admin endpoints documented",
+    ],
+    scan: [
+      "$ curl -s https://target/swagger.json | jq '.paths | keys'",
+      "[",
+      '  "/api/v1/login",',
+      '  "/api/internal/debug",',
+      '  "/api/admin/users",',
+      '  "/api/payments/refund"',
+      "]",
+    ],
+    attackerNext:
+      "Every parameter, auth scheme, and hidden admin route is now documented — the attacker skips reconnaissance and goes straight to abuse.",
+    impact: [
+      "Full enumeration of endpoints and parameters",
+      "Discovery of undocumented admin/internal APIs",
+      "Faster exploitation of broken-auth and IDOR flaws",
+      "Complete schema disclosure via GraphQL introspection",
+    ],
+    fixes: [
+      {
+        title: "1. Disable docs in prod",
+        detail: "Ship API docs to internal environments only.",
+        code: "if (env === 'production') disableSwagger()",
+      },
+      {
+        title: "2. Authenticate the docs",
+        detail: "Put any exposed docs behind real authentication.",
+        code: "Swagger UI behind SSO / auth proxy",
+      },
+      {
+        title: "3. Turn off introspection",
+        detail: "Disable GraphQL introspection in production.",
+        code: "introspection: false (prod)",
+      },
+      {
+        title: "4. Authorize every route",
+        detail: "Don't rely on obscurity; enforce authz at the gateway.",
+        code: "Gateway: authn + authz on all paths",
+      },
+    ],
+    bestPractices: [
+      { term: "No security by obscurity", text: "Assume attackers have your full API spec — secure each endpoint anyway." },
+      { term: "Environment separation", text: "Docs and introspection enabled in dev, disabled in prod." },
+      { term: "Gateway authorization", text: "Centralise authn/authz so no route is accidentally open." },
+      { term: "Surface monitoring", text: "Scan your own domains for exposed /swagger, /api-docs, /graphql." },
+    ],
+  },
+  {
+    id: "as04",
+    rank: 4,
+    shortId: "AS04",
+    title: "WordPress Admin Panel Exposed",
+    navTitle: "AS04 - WordPress Admin",
+    port: "HTTP/HTTPS",
+    stat: "15%",
+    cardDescription:
+      "Public /wp-admin and /wp-login.php — relentless credential guessing and plugin/theme CVE exploitation.",
+    summary:
+      "A publicly reachable /wp-admin, /wp-login.php, and xmlrpc.php invite automated credential guessing and exploitation of the enormous WordPress plugin and theme ecosystem. WordPress powers a huge share of the web, which makes its login and management interfaces some of the most relentlessly attacked surfaces online.",
+    examples: [
+      "Brute-force on /wp-login.php",
+      "xmlrpc.php amplified brute force",
+      "Vulnerable plugin/theme exploitation",
+    ],
+    scan: [
+      "$ wpscan --url https://target --enumerate u,vp",
+      "[+] /wp-login.php  -> 200 OK",
+      "[+] XML-RPC enabled (xmlrpc.php)",
+      "[+] User(s): admin, editor",
+      "[+] Plugin: contact-form 4.1.0 (known CVE)",
+    ],
+    attackerNext:
+      "With users enumerated and a vulnerable plugin found, the attacker brute-forces the login or fires a public exploit to drop a webshell.",
+    impact: [
+      "Full admin takeover of the site",
+      "Webshell upload and remote code execution",
+      "SEO spam, defacement, and malware distribution",
+      "Pivot from the web host into the rest of the environment",
+    ],
+    fixes: [
+      {
+        title: "1. Restrict the admin",
+        detail: "Limit /wp-admin to known IPs or put it behind a VPN.",
+        code: "Allow /wp-admin from office IPs / VPN only",
+      },
+      {
+        title: "2. Disable XML-RPC",
+        detail: "Turn off xmlrpc.php unless a feature truly needs it.",
+        code: "block xmlrpc.php at the web server",
+      },
+      {
+        title: "3. MFA + rate limiting",
+        detail: "Enforce strong passwords, MFA, and login throttling.",
+        code: "2FA plugin + fail2ban / login limiter",
+      },
+      {
+        title: "4. Patch & prune",
+        detail: "Keep core, themes, plugins current; remove unused ones.",
+        code: "auto-update core; uninstall stale plugins",
+      },
+    ],
+    bestPractices: [
+      { term: "Minimise the panel", text: "Don't expose management interfaces to the whole internet." },
+      { term: "Patch aggressively", text: "Plugin/theme CVEs are the #1 WordPress entry point." },
+      { term: "Strong auth", text: "MFA and unique passwords for every admin account." },
+      { term: "Monitoring", text: "Alert on login spikes and unexpected file changes." },
+    ],
+  },
+  {
+    id: "as05",
+    rank: 5,
+    shortId: "AS05",
+    title: "Remote Desktop (RDP) Exposed",
+    navTitle: "AS05 - RDP Exposed",
+    port: "3389/tcp",
+    stat: "11%",
+    cardDescription:
+      "RDP on 3389 facing the internet — one of the most common ransomware entry points.",
+    summary:
+      "RDP on port 3389 facing the internet remains one of the most common ransomware entry points. Attackers brute-force and password-spray credentials and exploit historical pre-authentication bugs such as BlueKeep (CVE-2019-0708). A single guessed password yields an interactive desktop on a server inside your network.",
+    examples: [
+      "Credential brute-force / password spray",
+      "BlueKeep (CVE-2019-0708) exploitation",
+      "Initial access for ransomware crews",
+    ],
+    scan: [
+      "$ nmap -p 3389 --script rdp-vuln-ms12-020,rdp-ntlm-info 198.51.100.20",
+      "PORT     STATE SERVICE",
+      "3389/tcp open  ms-wbt-server",
+      "| rdp-ntlm-info:",
+      "|   Target_Name: CORP",
+      "|   DNS_Computer_Name: FILESRV01.corp.local",
+      "|_  NLA: not enforced",
+    ],
+    attackerNext:
+      "The leaked hostname and domain feed a password-spray; without NLA, pre-auth exploits like BlueKeep are also on the table.",
+    impact: [
+      "Full interactive control of an internal server",
+      "Ransomware deployed directly from the desktop session",
+      "Lateral movement using harvested credentials",
+      "Active Directory compromise from a domain-joined host",
+    ],
+    fixes: [
+      {
+        title: "1. Don't expose RDP",
+        detail: "Reach it through a VPN, ZTNA, or RD Gateway only.",
+        code: "RDP via VPN / RD Gateway — never 0.0.0.0:3389",
+      },
+      {
+        title: "2. Enforce NLA + MFA",
+        detail: "Require Network Level Authentication and MFA.",
+        code: "Group Policy: NLA required; MFA at the gateway",
+      },
+      {
+        title: "3. Lockout & throttling",
+        detail: "Account lockout and rate limiting stop spraying.",
+        code: "Account lockout after N failures",
+      },
+      {
+        title: "4. Patch & restrict",
+        detail: "Apply OS patches and limit source IPs.",
+        code: "Patch BlueKeep; allow 3389 from jump host only",
+      },
+    ],
+    bestPractices: [
+      { term: "No direct exposure", text: "Remote admin belongs behind a VPN or zero-trust gateway." },
+      { term: "Strong auth", text: "NLA plus MFA defeats almost all credential attacks." },
+      { term: "Patch management", text: "Pre-auth RDP CVEs are wormable — patch fast." },
+      { term: "Monitoring", text: "Alert on RDP login bursts from unfamiliar geographies." },
+    ],
+  },
+  {
+    id: "as06",
+    rank: 6,
+    shortId: "AS06",
+    title: "SNMP Service Exposed",
+    navTitle: "AS06 - SNMP Exposed",
+    port: "161/udp",
+    stat: "9%",
+    cardDescription:
+      "Internet-facing SNMP — leaks device inventory and topology, and amplifies DDoS attacks.",
+    summary:
+      "SNMP is built for internal monitoring. Exposed to the internet — especially v1/v2c with the default `public` community string — it leaks device inventory, interfaces, routing and ARP tables, and sometimes credentials. A writable `private` community is even worse, and open SNMP is also abused as a DDoS amplifier.",
+    examples: [
+      "Default `public`/`private` community strings",
+      "Device and topology disclosure",
+      "SNMP reflection / amplification DDoS",
+    ],
+    scan: [
+      "$ snmpwalk -v2c -c public 203.0.113.5",
+      "SNMPv2-MIB::sysDescr.0 = Cisco IOS Software, C2960",
+      "SNMPv2-MIB::sysName.0 = core-sw-01",
+      "IF-MIB::ifDescr.2 = GigabitEthernet0/1",
+      "IP-MIB::ipAdEntAddr = 10.0.0.1, 10.0.5.0 ...",
+    ],
+    attackerNext:
+      "The attacker now has an internal network map; a writable `private` string would let them change device configuration outright.",
+    impact: [
+      "Detailed internal network and device mapping",
+      "Leakage of configuration and sometimes credentials",
+      "Device reconfiguration via a writable community string",
+      "Your host conscripted into reflection/amplification DDoS",
+    ],
+    fixes: [
+      {
+        title: "1. Don't expose 161/udp",
+        detail: "SNMP should never face the public internet.",
+        code: "Firewall: drop 161/udp from internet",
+      },
+      {
+        title: "2. Use SNMPv3",
+        detail: "Authenticated and encrypted; retire v1/v2c.",
+        code: "snmpv3 auth+priv (authPriv)",
+      },
+      {
+        title: "3. Replace defaults",
+        detail: "Remove `public`/`private`; use strong strings.",
+        code: "remove community 'public' / 'private'",
+      },
+      {
+        title: "4. Restrict & read-only",
+        detail: "Allow only monitoring hosts; prefer read-only views.",
+        code: "ACL: 161 from NMS only; read-only view",
+      },
+    ],
+    bestPractices: [
+      { term: "Keep it internal", text: "Management protocols stay on the management network." },
+      { term: "Authenticated SNMP", text: "SNMPv3 with auth+priv, never community strings." },
+      { term: "Least privilege", text: "Read-only views scoped to what monitoring needs." },
+      { term: "Anti-amplification", text: "Block spoofed/forwarded SNMP at the network edge." },
+    ],
+  },
+  {
+    id: "as07",
+    rank: 7,
+    shortId: "AS07",
+    title: "phpMyAdmin Panel Exposed",
+    navTitle: "AS07 - phpMyAdmin",
+    port: "HTTP/HTTPS",
+    stat: "8%",
+    cardDescription:
+      "A public phpMyAdmin login — a friendly browser gateway straight into MySQL/MariaDB.",
+    summary:
+      "A publicly reachable phpMyAdmin login is a direct web gateway to the underlying MySQL/MariaDB server. Attackers brute-force the login, fingerprint the version, and exploit known phpMyAdmin CVEs. On success they get full database control — read, write, dump, and in some configurations file write or code execution — all through a browser.",
+    examples: [
+      "Brute-force of the phpMyAdmin login",
+      "Known phpMyAdmin CVE exploitation",
+      "Full database control via the browser",
+    ],
+    scan: [
+      "$ curl -sI https://target/phpmyadmin/",
+      "HTTP/1.1 200 OK",
+      "$ curl -s https://target/phpmyadmin/README | head -1",
+      "phpMyAdmin 4.9.7",
+      "[*] login form reachable -> ready for brute-force",
+    ],
+    attackerNext:
+      "It's the same prize as an exposed database, but through a friendly UI: guess or exploit the login and the whole DB is one click away.",
+    impact: [
+      "Full read/write control of the database via the web",
+      "Data exfiltration and ransom",
+      "Code execution via SQL-to-file writes in some setups",
+      "A web-facing foothold to pivot onto the host",
+    ],
+    fixes: [
+      {
+        title: "1. Don't expose it",
+        detail: "Reach admin tools via VPN or an IP allowlist.",
+        code: "Allow /phpmyadmin from admin IPs / VPN only",
+      },
+      {
+        title: "2. Add an auth layer",
+        detail: "Put a reverse-proxy auth + MFA in front of it.",
+        code: "auth proxy + MFA before phpMyAdmin",
+      },
+      {
+        title: "3. Remove if unused",
+        detail: "Uninstall or rename the tool when not needed.",
+        code: "uninstall phpMyAdmin on prod",
+      },
+      {
+        title: "4. Patch & strong creds",
+        detail: "Keep it current and use strong DB credentials.",
+        code: "update phpMyAdmin; strong DB passwords",
+      },
+    ],
+    bestPractices: [
+      { term: "Minimise panels", text: "Database management UIs should never face the internet." },
+      { term: "Defence in depth", text: "Network restriction + proxy auth + strong DB creds." },
+      { term: "Patch management", text: "phpMyAdmin has a long CVE history — stay current." },
+      { term: "Surface monitoring", text: "Scan for /phpmyadmin, /pma, /dbadmin on your domains." },
+    ],
+  },
+  {
+    id: "as08",
+    rank: 8,
+    shortId: "AS08",
+    title: "UPnP Service Exposed",
+    navTitle: "AS08 - UPnP Exposed",
+    port: "1900/udp",
+    stat: "8%",
+    cardDescription:
+      "Internet-facing UPnP — lets attackers rewrite NAT rules, map internal hosts, and amplify DDoS.",
+    summary:
+      "Universal Plug and Play is designed for trusted local networks. Exposed on the WAN side (SSDP/IGD), it lets attackers manipulate port-forwarding and NAT rules, enumerate internal services and hosts, and abuse the device for SSDP reflection DDoS. It is a classic example of a protocol that was never meant to be internet-facing.",
+    examples: [
+      "WAN-side port-forward manipulation",
+      "Internal service/host disclosure",
+      "SSDP reflection / amplification DDoS",
+    ],
+    scan: [
+      "$ # SSDP discovery probe",
+      "M-SEARCH * HTTP/1.1  ST: ssdp:all",
+      "<- 200 OK  LOCATION: http://203.0.113.9:5000/rootDesc.xml",
+      "$ curl -s http://203.0.113.9:5000/rootDesc.xml | grep controlURL",
+      "<controlURL>/ctl/IPConn</controlURL>  (WANIPConnection)",
+    ],
+    attackerNext:
+      "With the IGD control URL the attacker can add their own port-forwards — exposing internal hosts straight to the internet.",
+    impact: [
+      "Attacker-controlled NAT rules that expose internal services",
+      "Reconnaissance of internal hosts and device details",
+      "SSDP reflection amplifying DDoS against third parties",
+      "Compromise of routers and IoT devices",
+    ],
+    fixes: [
+      {
+        title: "1. Disable WAN UPnP",
+        detail: "Never run UPnP/IGD on the internet-facing interface.",
+        code: "router: disable UPnP on WAN",
+      },
+      {
+        title: "2. Block SSDP inbound",
+        detail: "Drop 1900/udp arriving from the internet.",
+        code: "Firewall: drop 1900/udp inbound",
+      },
+      {
+        title: "3. Segment IoT",
+        detail: "Isolate consumer/IoT gear from critical systems.",
+        code: "VLAN: IoT segment, no lateral access",
+      },
+      {
+        title: "4. Patch firmware",
+        detail: "Update device firmware; use authenticated mgmt only.",
+        code: "firmware updates; authenticated remote mgmt",
+      },
+    ],
+    bestPractices: [
+      { term: "LAN-only by design", text: "UPnP belongs on trusted internal segments, never the WAN." },
+      { term: "Default-deny edge", text: "Block discovery/control protocols at the perimeter." },
+      { term: "Segmentation", text: "Keep IoT and consumer devices off the corporate network." },
+      { term: "Anti-amplification", text: "Filter spoofed traffic so your devices can't reflect DDoS." },
+    ],
+  },
+  {
+    id: "as09",
+    rank: 9,
+    shortId: "AS09",
+    title: "NTP Service Exposed",
+    navTitle: "AS09 - NTP Exposed",
+    port: "123/udp",
+    stat: "7%",
+    cardDescription:
+      "An open NTP server answering monlist — a powerful DDoS amplifier that also leaks recent clients.",
+    summary:
+      "An open NTP server that answers legacy `monlist` (and mode 6/7) queries is a powerful DDoS amplifier: a tiny spoofed request triggers a huge response aimed at the victim. It can also leak the list of recent clients, disclosing internal addresses and traffic patterns.",
+    examples: [
+      "monlist amplification (large factor)",
+      "Recent-client list disclosure",
+      "Participation in reflection DDoS",
+    ],
+    scan: [
+      "$ ntpdc -n -c monlist 198.51.100.7",
+      "remote address          count   m  ver",
+      "10.0.4.21               1832    7  2",
+      "10.0.4.22               1190    7  2",
+      "203.0.113.40             640    7  2",
+      "[*] small request -> large reply (amplification)",
+    ],
+    attackerNext:
+      "A spoofed monlist request turns this server into a DDoS cannon, and the reply quietly leaks recent internal clients.",
+    impact: [
+      "Your server weaponised in reflection/amplification DDoS",
+      "Disclosure of recent client and internal IP addresses",
+      "Reputation damage and IP blocklisting",
+      "Bandwidth and infrastructure costs from abuse",
+    ],
+    fixes: [
+      {
+        title: "1. Disable monlist",
+        detail: "Upgrade ntpd and turn off the monitor query.",
+        code: "disable monitor   # or use chrony",
+      },
+      {
+        title: "2. Restrict queries",
+        detail: "Default-deny status/config queries.",
+        code: "restrict default nomodify noquery notrap",
+      },
+      {
+        title: "3. Filter at the edge",
+        detail: "Block 123/udp for hosts that aren't time servers.",
+        code: "Firewall: 123/udp to NTP servers only",
+      },
+      {
+        title: "4. Anti-spoofing",
+        detail: "Deploy BCP38 ingress/egress filtering.",
+        code: "BCP38 source-address validation",
+      },
+    ],
+    bestPractices: [
+      { term: "Modern daemon", text: "Use a current ntpd or chrony without the monlist command." },
+      { term: "Default-deny", text: "Answer time, refuse status and config queries." },
+      { term: "Edge filtering", text: "Only real time servers should answer 123/udp from outside." },
+      { term: "Anti-amplification", text: "BCP38 filtering stops spoofed reflection at the source." },
+    ],
+  },
+  {
+    id: "as10",
+    rank: 10,
+    shortId: "AS10",
+    title: "RPC Portmapper Exposed",
+    navTitle: "AS10 - RPC Portmapper",
+    port: "111/tcp+udp",
+    stat: "7%",
+    cardDescription:
+      "An exposed rpcbind/portmapper — reveals internal RPC services (NFS, NIS) and amplifies DDoS.",
+    summary:
+      "The RPC portmapper (rpcbind) maps RPC programs such as NFS and NIS to their ports. It was never meant to face the internet, yet it remains accessible through misconfiguration. An exposed port 111 reveals which RPC services are running — a roadmap for targeting world-readable NFS exports and other legacy services — and is itself a DDoS amplification vector.",
+    examples: [
+      "RPC service enumeration via rpcinfo",
+      "Exposed NFS/NIS discovery",
+      "Portmap/rpcbind reflection DDoS",
+    ],
+    scan: [
+      "$ rpcinfo -p 192.0.2.20",
+      "   program vers proto   port  service",
+      "    100000    4   tcp    111  portmapper",
+      "    100003    3   tcp   2049  nfs",
+      "    100005    3   udp  35412  mountd",
+      "    100024    1   udp  47654  status",
+    ],
+    attackerNext:
+      "The service list points the attacker straight at the NFS export (often world-readable) or another legacy RPC service to exploit.",
+    impact: [
+      "A roadmap of internal RPC services to target",
+      "Data exposure via world-readable NFS exports",
+      "Portmap/rpcbind abused for amplification DDoS",
+      "Exploitation of legacy, unpatched RPC services",
+    ],
+    fixes: [
+      {
+        title: "1. Block port 111",
+        detail: "Never expose the portmapper to the internet.",
+        code: "Firewall: drop 111/tcp+udp from internet",
+      },
+      {
+        title: "2. Disable if unused",
+        detail: "Stop rpcbind where no RPC service needs it.",
+        code: "systemctl disable --now rpcbind",
+      },
+      {
+        title: "3. Restrict & lock NFS",
+        detail: "Limit to trusted hosts; tighten NFS exports.",
+        code: "/etc/exports: specific hosts, ro, root_squash",
+      },
+      {
+        title: "4. Modernise",
+        detail: "Use NFSv4 with authentication; segment legacy.",
+        code: "NFSv4 + Kerberos; isolate legacy RPC",
+      },
+    ],
+    bestPractices: [
+      { term: "Perimeter default-deny", text: "Legacy RPC services must never be reachable from outside." },
+      { term: "Disable the unused", text: "Turn off rpcbind/NFS where nothing depends on them." },
+      { term: "Lock down NFS", text: "Specific host lists, read-only where possible, root_squash on." },
+      { term: "Anti-amplification", text: "Filter spoofed 111/udp so rpcbind can't reflect DDoS." },
+    ],
+  },
+];


### PR DESCRIPTION
## What

Adds a third track to the demo: the **Top 10 Attack Surface Exposures (2026)**.

Unlike the OWASP Web/LLM tracks (application vulnerability classes), this track covers *exposures* — services and panels that should never have been reachable from the public internet. It's presented as a **single talk-through page** at `/asm` (no per-exposure sub-pages).

## Changes

- **`/asm` page** — a card per exposure (AS01–AS10) showing the share-of-surfaces stat, port/service, a one-line description, and examples. Each card has a collapsible **"Talk-through details"** section: recon scan output (what an attacker sees), impact, fixes with snippets, and best practices.
- **Headline surface stats** strip with a link to the source report (The Hacker News, "The Top 10 Attack Surface Exposures in 2026").
- **Landing page** card and a themed header for the track.
- **Docs** — adds `ATTACK_SURFACE_PRESENTATION_GUIDE.md` (per-exposure speaker script for the single-page flow) and replaces `PRESENTATION_GUIDE.md` with `OWASP_PRESENTATION_GUIDE.md`.

## Notes

- Static frontend content only — no backend changes, no live targets.
- `tsc --noEmit` passes.
