### PR TITLE
refactor: use React Router Link for next-buttons across Web and LLM tracks

### DIFF
--- a/frontend/src/components/A01BrokenAccessControl.tsx
+++ b/frontend/src/components/A01BrokenAccessControl.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import "./VulnerabilityPage.css";
 
@@ -321,9 +322,9 @@ public class UsersController : ControllerBase
       </div>
 
       <div className="navigation-section">
-        <a href="/web/a02" className="next-button">
+        <Link to="/web/a02" className="next-button">
           Next: A02 - Cryptographic Failures →
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/A02CryptographicFailures.tsx
+++ b/frontend/src/components/A02CryptographicFailures.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import "./VulnerabilityPage.css";
 
@@ -257,9 +258,9 @@ public string CreateSecureJWT(ClaimsPrincipal user)
       </div>
 
       <div className="navigation-section">
-        <a href="/web/a03" className="next-button">
+        <Link to="/web/a03" className="next-button">
           Next: A03 - Injection →
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/A03Injection.tsx
+++ b/frontend/src/components/A03Injection.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import "./VulnerabilityPage.css";
 
@@ -282,9 +283,9 @@ public async Task<User> FindUserByUsernameAsync(string username)
       </div>
 
       <div className="navigation-section">
-        <a href="/web/a04" className="next-button">
+        <Link to="/web/a04" className="next-button">
           Next: A04 - Insecure Design →
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/A04InsecureDesign.tsx
+++ b/frontend/src/components/A04InsecureDesign.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import "./VulnerabilityPage.css";
 
@@ -297,9 +298,9 @@ public class MfaService
       </div>
 
       <div className="navigation-section">
-        <a href="/web/a05" className="next-button">
+        <Link to="/web/a05" className="next-button">
           Next: A05 - Security Misconfiguration →
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/A05SecurityMisconfiguration.tsx
+++ b/frontend/src/components/A05SecurityMisconfiguration.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import "./VulnerabilityPage.css";
 
@@ -308,9 +309,9 @@ public class ConfigurationValidator
       </div>
 
       <div className="navigation-section">
-        <a href="/web/a06" className="next-button">
+        <Link to="/web/a06" className="next-button">
           Next: A06 - Vulnerable Components →
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/A06VulnerableComponents.tsx
+++ b/frontend/src/components/A06VulnerableComponents.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import "./VulnerabilityPage.css";
 
@@ -340,9 +341,9 @@ public class VulnerabilityScanner
       </div>
 
       <div className="navigation-section">
-        <a href="/web/a07" className="next-button">
+        <Link to="/web/a07" className="next-button">
           Next: A07 - Authentication Failures →
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/A07AuthenticationFailures.tsx
+++ b/frontend/src/components/A07AuthenticationFailures.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import "./VulnerabilityPage.css";
 
@@ -386,9 +387,9 @@ public class TokenService : ITokenService
       </div>
 
       <div className="navigation-section">
-        <a href="/web/a08" className="next-button">
+        <Link to="/web/a08" className="next-button">
           Next: A08 - Integrity Failures →
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/A08IntegrityFailures.tsx
+++ b/frontend/src/components/A08IntegrityFailures.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import "./VulnerabilityPage.css";
 
@@ -409,9 +410,9 @@ public class DeploymentIntegrityChecker
       </div>
 
       <div className="navigation-section">
-        <a href="/web/a09" className="next-button">
+        <Link to="/web/a09" className="next-button">
           Next: A09 - Logging Failures →
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/A09LoggingFailures.tsx
+++ b/frontend/src/components/A09LoggingFailures.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import "./VulnerabilityPage.css";
 
@@ -350,9 +351,9 @@ public class AuthenticationLoggingMiddleware
       </div>
 
       <div className="navigation-section">
-        <a href="/web/a10" className="next-button">
+        <Link to="/web/a10" className="next-button">
           Next: A10 - SSRF →
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/A10SSRF.tsx
+++ b/frontend/src/components/A10SSRF.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import "./VulnerabilityPage.css";
 
@@ -439,9 +440,9 @@ public class FetchUrlRequest
       </div>
 
       <div className="navigation-section">
-        <a href="/web" className="next-button">
+        <Link to="/web" className="next-button">
           Presentation Complete - Return Home →
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/llm/LLM01PromptInjection.tsx
+++ b/frontend/src/components/llm/LLM01PromptInjection.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import { useLLMStream } from "../../hooks/useLLMStream";
 import "../VulnerabilityPage.css";
 
@@ -143,9 +144,9 @@ const LLM01PromptInjection: React.FC = () => {
       </div>
 
       <div className="navigation-section">
-        <a href="/llm/l02" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
+        <Link to="/llm/l02" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
           Next: LLM02 - Sensitive Information Disclosure &rarr;
-        </a>
+        </Link>
       </div>
 
       <style>{`

--- a/frontend/src/components/llm/LLM02SensitiveInfoDisclosure.tsx
+++ b/frontend/src/components/llm/LLM02SensitiveInfoDisclosure.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import { useLLMStream } from "../../hooks/useLLMStream";
 import "../VulnerabilityPage.css";
 
@@ -114,9 +115,9 @@ const LLM02SensitiveInfoDisclosure: React.FC = () => {
       </div>
 
       <div className="navigation-section">
-        <a href="/llm/l03" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
+        <Link to="/llm/l03" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
           Next: LLM03 - Supply Chain &rarr;
-        </a>
+        </Link>
       </div>
 
       <style>{`

--- a/frontend/src/components/llm/LLM03SupplyChain.tsx
+++ b/frontend/src/components/llm/LLM03SupplyChain.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import "../VulnerabilityPage.css";
 
@@ -163,9 +164,9 @@ const LLM03SupplyChain: React.FC = () => {
       </div>
 
       <div className="navigation-section">
-        <a href="/llm/l04" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
+        <Link to="/llm/l04" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
           Next: LLM04 - Data and Model Poisoning &rarr;
-        </a>
+        </Link>
       </div>
     </div>
   );

--- a/frontend/src/components/llm/LLM04DataPoisoning.tsx
+++ b/frontend/src/components/llm/LLM04DataPoisoning.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import { useLLMStream } from "../../hooks/useLLMStream";
 import "../VulnerabilityPage.css";
@@ -189,9 +190,9 @@ const LLM04DataPoisoning: React.FC = () => {
       </div>
 
       <div className="navigation-section">
-        <a href="/llm/l05" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
+        <Link to="/llm/l05" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
           Next: LLM05 - Improper Output Handling &rarr;
-        </a>
+        </Link>
       </div>
 
       <style>{`

--- a/frontend/src/components/llm/LLM05ImproperOutputHandling.tsx
+++ b/frontend/src/components/llm/LLM05ImproperOutputHandling.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import { useLLMStream } from "../../hooks/useLLMStream";
 import "../VulnerabilityPage.css";
@@ -169,9 +170,9 @@ const LLM05ImproperOutputHandling: React.FC = () => {
       </div>
 
       <div className="navigation-section">
-        <a href="/llm/l06" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
+        <Link to="/llm/l06" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
           Next: LLM06 - Excessive Agency &rarr;
-        </a>
+        </Link>
       </div>
 
       <style>{`

--- a/frontend/src/components/llm/LLM06ExcessiveAgency.tsx
+++ b/frontend/src/components/llm/LLM06ExcessiveAgency.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import { useLLMStream } from "../../hooks/useLLMStream";
 import "../VulnerabilityPage.css";
@@ -134,9 +135,9 @@ const LLM06ExcessiveAgency: React.FC = () => {
       </div>
 
       <div className="navigation-section">
-        <a href="/llm/l07" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
+        <Link to="/llm/l07" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
           Next: LLM07 - System Prompt Leakage &rarr;
-        </a>
+        </Link>
       </div>
 
       <style>{`

--- a/frontend/src/components/llm/LLM07SystemPromptLeakage.tsx
+++ b/frontend/src/components/llm/LLM07SystemPromptLeakage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import { useLLMStream } from "../../hooks/useLLMStream";
 import "../VulnerabilityPage.css";
@@ -133,9 +134,9 @@ const LLM07SystemPromptLeakage: React.FC = () => {
       </div>
 
       <div className="navigation-section">
-        <a href="/llm/l08" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
+        <Link to="/llm/l08" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
           Next: LLM08 - Vector and Embedding Weaknesses &rarr;
-        </a>
+        </Link>
       </div>
 
       <style>{`

--- a/frontend/src/components/llm/LLM08VectorEmbeddingWeaknesses.tsx
+++ b/frontend/src/components/llm/LLM08VectorEmbeddingWeaknesses.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import { useLLMStream } from "../../hooks/useLLMStream";
 import "../VulnerabilityPage.css";
@@ -196,9 +197,9 @@ const LLM08VectorEmbeddingWeaknesses: React.FC = () => {
       </div>
 
       <div className="navigation-section">
-        <a href="/llm/l09" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
+        <Link to="/llm/l09" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
           Next: LLM09 - Misinformation &rarr;
-        </a>
+        </Link>
       </div>
 
       <style>{`

--- a/frontend/src/components/llm/LLM09Misinformation.tsx
+++ b/frontend/src/components/llm/LLM09Misinformation.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import { useLLMStream } from "../../hooks/useLLMStream";
 import "../VulnerabilityPage.css";
@@ -178,9 +179,9 @@ const LLM09Misinformation: React.FC = () => {
       </div>
 
       <div className="navigation-section">
-        <a href="/llm/l10" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
+        <Link to="/llm/l10" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
           Next: LLM10 - Unbounded Consumption &rarr;
-        </a>
+        </Link>
       </div>
 
       <style>{`

--- a/frontend/src/components/llm/LLM10UnboundedConsumption.tsx
+++ b/frontend/src/components/llm/LLM10UnboundedConsumption.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { Link } from "react-router-dom";
 import axios from "axios";
 import { useLLMStream } from "../../hooks/useLLMStream";
 import "../VulnerabilityPage.css";
@@ -202,9 +203,9 @@ const LLM10UnboundedConsumption: React.FC = () => {
       </div>
 
       <div className="navigation-section">
-        <a href="/llm" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
+        <Link to="/llm" className="next-button" style={{ background: "linear-gradient(135deg, #00ced1, #8a2be2)" }}>
           &larr; Back to LLM Top 10 Home
-        </a>
+        </Link>
       </div>
 
       <style>{`


### PR DESCRIPTION
## What

Standardizes the "Next" navigation buttons on the Web and LLM vulnerability pages to use React Router's `<Link>` instead of plain `<a href>`.

## Why

The `<a href>` buttons triggered a full-page reload when advancing through the demo (e.g. A01 → A02, LLM01 → LLM02), which is jarring during a presentation and inconsistent with the rest of the SPA. `<Link>` does client-side navigation.

## Changes

- All `A01`–`A10` pages: `import { Link }` and swap the next-button `<a href>` for `<Link to>`.
- All `LLM01`–`LLM10` pages: same change (styling/gradient preserved).

No behavioural change beyond avoiding the reload. `tsc --noEmit` passes.
